### PR TITLE
In the error message, print value (%v) instead of assuming a string or byte slice (%s)

### DIFF
--- a/ssh_exporter_test.go
+++ b/ssh_exporter_test.go
@@ -197,7 +197,7 @@ func TestIntegrationHappyPath(t *testing.T) {
 	// Make sure the status is correct
 	// If this fails we have weirder problems
 	if want, have := http.StatusOK, resp.StatusCode; want != have {
-		t.Errorf("Status code was not OK: %s != %s\n%s", want, have, string(data))
+		t.Errorf("Status code was not OK: %v != %v\n%s", want, have, string(data))
 		t.Fail()
 	}
 


### PR DESCRIPTION
StatusText says it returns an string
But
http.StatusOK is returning a int
resp.StatusCode is returning a int

Since this is an error message, if it fails, might as well give the value as we received it in the error message.

"data" is already being converted, so the %s works.